### PR TITLE
DE516410 Fixed the Intesa case related to the new released InjectionFilterAssertion

### DIFF
--- a/src/main/java/com/l7tech/custom/assertions/injectionfilter/console/InjectionFilterAssertionDialog.java
+++ b/src/main/java/com/l7tech/custom/assertions/injectionfilter/console/InjectionFilterAssertionDialog.java
@@ -143,9 +143,11 @@ class InjectionFilterAssertionDialog extends JDialog implements AssertionEditor 
         for (final Map.Entry<String, byte[]> entry : injectionFilterByteMap.entrySet()) {
             final String key = entry.getKey();
             final InjectionFilterEntity entity = serializer.deserialize(entry.getValue());
-            comboBoxItem = new FilterComboBoxItem(key, entity);
-            filterComboBox.addItem(comboBoxItem);
-            keyToFilterMap.put(key, comboBoxItem);
+            if (entity != null) {
+                comboBoxItem = new FilterComboBoxItem(key, entity);
+                filterComboBox.addItem(comboBoxItem);
+                keyToFilterMap.put(key, comboBoxItem);
+            }
         }
     }
 

--- a/src/main/java/com/l7tech/custom/assertions/injectionfilter/entity/InjectionFilterEntity.java
+++ b/src/main/java/com/l7tech/custom/assertions/injectionfilter/entity/InjectionFilterEntity.java
@@ -8,6 +8,7 @@ import java.util.Collections;
 import java.util.List;
 
 public class InjectionFilterEntity implements Serializable {
+    private static final long serialVersionUID = 3231009958979046483L;
 
     private String filterName;
     private String description;


### PR DESCRIPTION
[Issue]
After a policy with an old version of InjectionFilterAssertion (sdk82-1.0-2559) is imported in the policy manager connecting to a GW 10.1 with the new version of InjectionFilterAssertion (1.1.0) installed, if you double click the assertion in the policy manager, a NPE will be thrown.  After the NPE fixed, double clicking the assertion will throw "Error while deserializing Injection Filter" and "InvalidClassException".
 
[Root Cause Analysis]

The policy manager logs show "Error while deserializing Injection Filter" and "InvalidClassException".  The root cause of the issue is when InjectionFilterSerializer deserializes the custom assertion to get InjectionFilterEntity containing the information of Filter Name, InjectionFilterSerializer throws InvalidClassException, because the old assertion and the new assertion have different serialVersionUID on InjectionFilterEntity, i.e., two types of InjectionFilterEntity are incompatible from two different assertion jars.

[Solution]

Obtain a serialVersionUID of InjectionFilterEntity from the old assertion, assign the same serialVersionUID of InjectionFilterEntity in the new assertion, and re-generate a signed assertion jar.


[Test]

After uploading the new signed jar, import the old policy.  When the assertion is double-clicked in the policy manager, the assertion dialog shows up and the configuration of the Injection Filter is correctly shown.  